### PR TITLE
Pin Node version so that `npm ci` and CI/CD pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  node: circleci/node@3.0.0
+
 commands:
   run-tox:
     description: "Run tox"
@@ -16,6 +19,8 @@ commands:
   run-build:
     description: "Ensure built assets are up to date"
     steps:
+      - node/install:
+          node-version: '14.18.1'
       - checkout
       - run: npm ci
       - run: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ commands:
   run-build:
     description: "Ensure built assets are up to date"
     steps:
+      - checkout
       - node/install:
           node-version: '14.18.1'
-      - checkout
       - run: npm ci
       - run: npm run build
       - run:


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Pin Node version to `14.18.1` using the [circleci/node](https://circleci.com/developer/orbs/orb/circleci/node) orb
* This might not be the best solution, it might be better to bump the `package.json` dependencies
* But this shows how to get a build to pass
