### PR TITLE
Pin the Node version to 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  node: circleci/node@3.0.0
+
 commands:
   run-tox:
     description: "Run tox"
@@ -17,6 +20,8 @@ commands:
     description: "Ensure built assets are up to date"
     steps:
       - checkout
+      - node/install:
+          node-version: '14.18.1'
       - run: npm ci
       - run: npm run build
       - run:


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Pin the Node version to `14` to avoid `node-gyp` errors


